### PR TITLE
Enhance monitor command with interval-based polling

### DIFF
--- a/src/sentinel/sentinel/cli.py
+++ b/src/sentinel/sentinel/cli.py
@@ -10,6 +10,8 @@ def main():
     # Monitor command
     monitor_parser = subparsers.add_parser("monitor", help="Monitor an API endpoint")
     monitor_parser.add_argument("url", help="API URL to monitor")
+    monitor_parser.add_argument("--interval", type=int, default=0, help="Monitoring interval")
+    monitor_parser.add_argument("--count", type=int, default=1, help="Stop monitoring after N intervals")
 
     # Load Test command
     load_test_parser = subparsers.add_parser("loadtest", help="Run a load test on an API endpoint")
@@ -19,7 +21,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "monitor":
-        monitor_api(args.url)
+        monitor_api(args.url, args.interval, args.count)
     elif args.command == "loadtest":
         load_test_api(args.url, args.requests)
 

--- a/src/sentinel/sentinel/monitor.py
+++ b/src/sentinel/sentinel/monitor.py
@@ -1,10 +1,29 @@
 import requests
+from time import sleep
 
-def monitor_api(url):
-    try:
-        response = requests.get(url)
-        print(f"Status Code: {response.status_code}")
-        return {"status": response.status_code}
-    except requests.RequestException as e:
-        print(f"Error: {e}")
-        return {"error": str(e)}
+def monitor_api(url, interval=0, count=1):
+    if interval == 0:
+        try:
+            response = requests.get(url)
+            print(f"Status Code: {response.status_code}")
+            return {"status": response.status_code}
+        except requests.RequestException as e:
+            print(f"Error: {e}")
+            return {"error": str(e)}
+    elif interval > 0:
+        counter = 0
+        while True:
+            try:
+                if counter < count:
+                    response = requests.get(url)
+                    print(f"Status Code: {response.status_code}")
+                    sleep(interval)
+                    counter += 1
+                else:
+                    break
+            except requests.RequestException as e:
+                print(f"Error: {e}")
+                return {"error": str(e)}
+            except KeyboardInterrupt:
+                print("Monitoring stopped by user")
+                return

--- a/src/sentinel/tests/test_cli.py
+++ b/src/sentinel/tests/test_cli.py
@@ -4,7 +4,7 @@ from sentinel import cli
 def test_cli_monitor(monkeypatch):
     called = {}
 
-    def mock_monitor_api(url):
+    def mock_monitor_api(url, interval, count):
         called['url'] = url
 
     monkeypatch.setattr('sentinel.cli.monitor_api', mock_monitor_api)

--- a/src/sentinel/tests/test_monitor.py
+++ b/src/sentinel/tests/test_monitor.py
@@ -1,5 +1,33 @@
+import pytest
+import sys
+from sentinel import cli
 from sentinel.monitor import monitor_api
 
 def test_monitor_api():
     result = monitor_api("https://httpbin.org/get")
     assert result['status'] == 200
+
+def test_monitor_with_interval_and_count(monkeypatch):
+    called_urls = []
+
+    # Mock monitor_api to track calls
+    def mock_monitor_api(url, interval=0, count=1):
+        for _ in range(count):
+            called_urls.append(url)
+
+    # Mock time.sleep to skip actual delay
+    monkeypatch.setattr("time.sleep", lambda x: None)
+
+    # Replace the real function with mock
+    monkeypatch.setattr("sentinel.cli.monitor_api", mock_monitor_api)
+
+    # Simulate CLI args: sentinel monitor <url> --interval 1 --count 3
+    test_args = ['sentinel', 'monitor', 'https://example.com', '--interval', '2', '--count', '3']
+    monkeypatch.setattr(sys, 'argv', test_args)
+
+    # Run the CLI
+    cli.main()
+
+    # Assert the API was called 3 times
+    assert len(called_urls) == 3
+    assert all(url == 'https://example.com' for url in called_urls)


### PR DESCRIPTION
# Enhancement
This update enhances the monitor command by adding support for interval-based polling.  

## Usage
Users can now specify:
```
--interval N
```
(in seconds) and
```
--count N
```
(number of times to poll) to repeatedly check an API endpoint on a schedule.

## Roadmap
This feature lays the groundwork for more advanced monitoring capabilities in future updates.  

## Known Issues
There are no known issues at this time.