### PR TITLE
Refactor: Move request logic to requests module

### DIFF
--- a/src/sentinel/sentinel/monitor.py
+++ b/src/sentinel/sentinel/monitor.py
@@ -1,29 +1,20 @@
-import requests
+from sentinel.utils.requests import send_request
 from time import sleep
 
 def monitor_api(url, interval=0, count=1):
+    result = {}
     if interval == 0:
-        try:
-            response = requests.get(url)
-            print(f"Status Code: {response.status_code}")
-            return {"status": response.status_code}
-        except requests.RequestException as e:
-            print(f"Error: {e}")
-            return {"error": str(e)}
+        return send_request(url)
     elif interval > 0:
         counter = 0
         while True:
             try:
                 if counter < count:
-                    response = requests.get(url)
-                    print(f"Status Code: {response.status_code}")
+                    result = send_request(url)
                     sleep(interval)
                     counter += 1
                 else:
                     break
-            except requests.RequestException as e:
-                print(f"Error: {e}")
-                return {"error": str(e)}
             except KeyboardInterrupt:
                 print("Monitoring stopped by user")
                 return

--- a/src/sentinel/sentinel/utils/requests.py
+++ b/src/sentinel/sentinel/utils/requests.py
@@ -1,0 +1,10 @@
+import requests
+
+def send_request(url):
+    try:
+        response = requests.get(url)
+        print(f"Status Code: {response.status_code}")
+        return {"status": response.status_code}
+    except requests.RequestException as e:
+        print(f"Error: {e}")
+        return {"error": str(e)}


### PR DESCRIPTION
This PR refactors reusable HTTP request logic into a new send_request() helper function located in utils/requests.py. The monitor.py module has been updated to use this function, reducing code duplication and improving maintainability.

- Promotes DRY principles across the codebase
- Validated changes using existing tests
- loadtest.py will be refactored in a future PR due to additional complexity

This is a foundational cleanup to support better modularization of HTTP logic going forward.