### PR TITLE
Add setup.py and package Sentinel for CLI use

### DIFF
--- a/src/sentinel/setup.py
+++ b/src/sentinel/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="sentinel",
+    version="0.1.0",
+    description="API Monitoring & Load Testing CLI Tool",
+    author="Jason Alan Smith",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "requests"
+    ],
+    entry_points={
+        "console_scripts": [
+            "sentinel=sentinel.cli:main"
+        ]
+    },
+    python_requires=">=3.8",
+)


### PR DESCRIPTION
This PR packages Sentinel as a proper Python module using setup.py and setuptools. Key updates:
- Added setup.py to support pip installation via pip install -e .
- Defined console_scripts entry point for global sentinel CLI command
- Validated that sentinel monitor and sentinel loadtest work from terminal

This change sets the foundation for future distribution, cleaner development tooling, and easier integration with test runners and CI.